### PR TITLE
Apply basename for BrowserRouter

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,7 +11,7 @@ import store from './store';
 ReactDOM.render(
   (
     <Provider store={store}>
-      <BrowserRouter>
+      <BrowserRouter basename={process.env.PUBLIC_URL}>
         <App />
       </BrowserRouter>
     </Provider>


### PR DESCRIPTION
- 깃허브 페이지에서 흰색 화면만 출력되는 문제를 해결하는 중입니다.
- 브라우저 라우터에 루트 URL을 적용해봤습니다.